### PR TITLE
Set up deployment to Github Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: 'npm'
+      
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Build with Next.js
+        run: npm run build
+      
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,10 @@ import createMDX from "@next/mdx";
 
 const nextConfig: NextConfig = {
     pageExtensions: ["md", "mdx", "ts", "tsx"],
+    output: 'export',
+    images: {
+        unoptimized: true,
+    },
 };
 
 const withMDX = createMDX();


### PR DESCRIPTION
Roo thinks this is all it takes to deploy the site to Github Pages - gonna give it a shot.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set up GitHub Actions workflow for deploying a Next.js site to GitHub Pages with static export and unoptimized images.
> 
>   - **GitHub Actions Workflow**:
>     - Adds `.github/workflows/deploy.yml` to automate deployment to GitHub Pages on `main` branch push or manual trigger.
>     - Configures permissions for `GITHUB_TOKEN` and ensures single concurrent deployment.
>     - Defines `build` job to checkout code, setup Node.js, install dependencies, build with Next.js, and upload artifacts.
>     - Defines `deploy` job to deploy artifacts to GitHub Pages.
>   - **Next.js Configuration**:
>     - Updates `next.config.ts` to set `output: 'export'` for static export.
>     - Configures images to be `unoptimized` in `next.config.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Website&utm_source=github&utm_medium=referral)<sup> for 070cbf97624dee65760daf0a59a44bdae401e495. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->