### PR TITLE
fix feature cards height to fit content in carousel view

### DIFF
--- a/src/components/homepage/features-mobile.tsx
+++ b/src/components/homepage/features-mobile.tsx
@@ -59,8 +59,8 @@ export function FeaturesMobile() {
                 <div className="overflow-hidden" ref={emblaRef}>
                     <div className="flex">
                         {features.map((feature, index) => (
-                            <div className="min-w-0 flex-[0_0_100%] px-4" key={index}>
-                                <div className="relative h-[280px] rounded-2xl border border-border/50 bg-background/30 p-6 backdrop-blur-xl transition-colors duration-300 hover:border-border hover:bg-gray-900/20">
+                            <div className="flex min-w-0 flex-[0_0_100%] px-4" key={index}>
+                                <div className="relative h-full min-h-[280px] rounded-2xl border border-border/50 bg-background/30 p-6 backdrop-blur-xl transition-colors duration-300 hover:border-border hover:bg-gray-900/20">
                                     <div className="mb-2 inline-flex items-center justify-center rounded-xl bg-gradient-to-r from-blue-500/5 to-cyan-500/5 p-2.5">
                                         <div className="rounded-lg bg-gradient-to-r from-blue-500/80 to-cyan-500/80 p-2.5">
                                             <div className="text-foreground/90">{feature.icon}</div>


### PR DESCRIPTION
feature descriptions were being cut off due to fixed height constraints. cards should now properly expand to fit their content but continue to maintain a consistent minimum height
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes feature card height in `FeaturesMobile` to fit content dynamically while maintaining a minimum height.
> 
>   - **Behavior**:
>     - Adjusts card height in `FeaturesMobile` component to fit content by changing `h-[280px]` to `h-full min-h-[280px]`.
>     - Ensures cards maintain a consistent minimum height of 280px.
>   - **CSS Changes**:
>     - Modifies CSS classes in `features-mobile.tsx` to allow dynamic height adjustment for feature cards.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Website&utm_source=github&utm_medium=referral)<sup> for 025d12dd87280eb94d09b77554259557db3f7034. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->