### PR TITLE
seo: add Google site name metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,6 @@ import "./globals.css";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
-import Head from "next/head";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -15,21 +14,12 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
         <html lang="en" suppressHydrationWarning>
-            <Head>
-                {/* google site name: https://developers.google.com/search/docs/appearance/site-names */}
-                <script
-                    type="application/ld+json"
-                    dangerouslySetInnerHTML={{
-                        __html: JSON.stringify({
-                            "@context": "https://schema.org",
-                            "@type": "WebSite",
-                            name: "Roo Code",
-                            url: "https://roocode.com/",
-                        }),
-                    }}
-                />
-            </Head>
             <body className={inter.className}>
+                {/* google site name: https://developers.google.com/search/docs/appearance/site-names */}
+                <div itemScope itemType="https://schema.org/WebSite">
+                    <link itemProp="url" href="https://roocode.com" />
+                    <meta itemProp="name" content="Roo Code" />
+                </div>
                 <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
                     {children}
                 </ThemeProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
+import Head from "next/head";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -14,6 +15,20 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
         <html lang="en" suppressHydrationWarning>
+            <Head>
+                {/* google site name: https://developers.google.com/search/docs/appearance/site-names */}
+                <script
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{
+                        __html: JSON.stringify({
+                            "@context": "https://schema.org",
+                            "@type": "WebSite",
+                            name: "Roo Code",
+                            url: "https://roocode.com/",
+                        }),
+                    }}
+                />
+            </Head>
             <body className={inter.className}>
                 <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
                     {children}


### PR DESCRIPTION
reference: https://developers.google.com/search/docs/appearance/site-names 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add Google site name metadata to `layout.tsx` for improved SEO.
> 
>   - **SEO Enhancement**:
>     - Adds Google site name metadata in `layout.tsx` using `itemScope` and `itemType` attributes.
>     - Includes `<link>` with `itemProp="url"` and `<meta>` with `itemProp="name"` for `https://roocode.com` and "Roo Code" respectively.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Website&utm_source=github&utm_medium=referral)<sup> for 30932bc5c61a52297c1b5c24f545b32858ed6202. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->